### PR TITLE
Add new props for both charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1121,7 +1121,7 @@ The initial location of the indicator when `alwaysShowIndicator` is `true`. The 
 <tr>
 <td align="center">
   
-  ##### `lineSliceIndex`
+  ##### `lineSliceEndIndex`
 </td>
 <td align="center">
 
@@ -1137,7 +1137,7 @@ number
 </td>
 <td align="left">
 
-Optional index of the data where the line chart should be sliced.
+Optional data index where we should stop drawing the AreaChart line. Results in a discontinuous graph with a hard stop after a certain data point, given by `lineSliceEndIndex`.
 
 </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -1118,6 +1118,29 @@ The initial location of the indicator when `alwaysShowIndicator` is `true`. The 
 
 </td>
 </tr>
+<tr>
+<td align="center">
+  
+  ##### `lineSliceIndex`
+</td>
+<td align="center">
+
+```ts
+number
+```
+
+</td>
+<td align="center">
+
+`undefined`
+
+</td>
+<td align="left">
+
+Optional index of the data where the line chart should be sliced.
+
+</td>
+</tr>
 </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -929,6 +929,53 @@ This callback is fired when the bar selection has changed via touch. This can be
 
 </td>
 </tr>
+<tr>
+<td align="center">
+  
+  ##### `barDynamicColor`
+</td>
+<td align="center">
+
+```ts
+({ x: number | Date,
+  y: number,
+  index: number })
+  => string
+```
+
+</td>
+<td align="center">
+
+`undefined`
+
+</td>
+<td align="left">
+
+Function that takes the x and y value and the index of a data point and returns a color to fill the bars of the bar chart dynamically. This makes it possible to have different colors for the bars in a chart. Takes precedence over `fillColor` and `renderFillGradient` when applied.
+
+</td>
+</tr>
+<tr>
+<td align="center">
+  
+  ##### `initialBarSelected`
+</td>
+<td align="center">
+
+`number`
+
+</td>
+<td align="center">
+
+`undefined`
+
+</td>
+<td align="left">
+
+The initial bar that should be selected when `alwaysShowIndicator` is `true`. The `number` represents the index of the data point / bar that should be selected.
+
+</td>
+</tr>
 </tbody>
 </table>
 
@@ -1044,6 +1091,30 @@ Color for the line designating the data charted.
 <td align="left">
 
 Stroke width of the line designating the data charted.
+
+</td>
+</tr>
+<tr>
+<td align="center">
+  
+  ##### `initialIndicatorPosition`
+</td>
+<td align="center">
+
+```ts
+number | 'middle'
+| 'start' | 'end'
+```
+
+</td>
+<td align="center">
+
+`middle`
+
+</td>
+<td align="left">
+
+The initial location of the indicator when `alwaysShowIndicator` is `true`. The `number` represents the index of the data point / bar that should be selected.
 
 </td>
 </tr>

--- a/src/lib/SlideAreaChart.tsx
+++ b/src/lib/SlideAreaChart.tsx
@@ -305,7 +305,7 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
       }
     }
     const {
-      cursorProps, axisWidth, toolTipProps, callbackWithX, callbackWithY, paddingLeft,
+      cursorProps, axisWidth, toolTipProps, callbackWithX, callbackWithY, paddingLeft, data, lineSliceIndex
     } = this.props
 
     const toolTipTextRenderers = toolTipProps?.toolTipTextRenderers || []
@@ -313,9 +313,12 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
     const cursorMarkerWidth = cursorProps?.cursorMarkerWidth ?? defaultCursorProps.cursorMarkerWidth
     const cursorLineWidth = cursorProps?.cursorWidth ?? defaultCursorProps.cursorWidth
     const yRangeCalculated = this.calculateYRange()
+    const lineSlicePosition = this.chartWidth * (lineSliceIndex / Math.max(data.length - 1, 1))
 
     if (value < 0) {
       value = 0
+    } else if (value > lineSlicePosition) {
+      value = lineSlicePosition;
     } else if (value > this.chartWidth) {
       value = this.chartWidth
     }
@@ -590,6 +593,7 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
       paddingRight,
       chartPaddingTop,
       onPress,
+      lineSliceIndex,
     } = this.props
 
     this.chartWidth = width - axisWidth - paddingLeft - paddingRight
@@ -650,6 +654,7 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
           paddingTop={paddingTop}
           xAxisProps={xAxisProps}
           yAxisProps={yAxisProps}
+          lineSliceIndex={lineSliceIndex}
         />
         {!onPress && <Cursor
           ref={this.cursor}

--- a/src/lib/SlideAreaChart.tsx
+++ b/src/lib/SlideAreaChart.tsx
@@ -305,7 +305,7 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
       }
     }
     const {
-      cursorProps, axisWidth, toolTipProps, callbackWithX, callbackWithY, paddingLeft, data, lineSliceIndex
+      cursorProps, axisWidth, toolTipProps, callbackWithX, callbackWithY, paddingLeft, data, lineSliceEndIndex
     } = this.props
 
     const toolTipTextRenderers = toolTipProps?.toolTipTextRenderers || []
@@ -313,7 +313,7 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
     const cursorMarkerWidth = cursorProps?.cursorMarkerWidth ?? defaultCursorProps.cursorMarkerWidth
     const cursorLineWidth = cursorProps?.cursorWidth ?? defaultCursorProps.cursorWidth
     const yRangeCalculated = this.calculateYRange()
-    const lineSlicePosition = this.chartWidth * (lineSliceIndex / Math.max(data.length - 1, 1))
+    const lineSlicePosition = this.chartWidth * (lineSliceEndIndex / Math.max(data.length - 1, 1))
 
     if (value < 0) {
       value = 0
@@ -593,7 +593,7 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
       paddingRight,
       chartPaddingTop,
       onPress,
-      lineSliceIndex,
+      lineSliceEndIndex,
     } = this.props
 
     this.chartWidth = width - axisWidth - paddingLeft - paddingRight
@@ -654,7 +654,7 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
           paddingTop={paddingTop}
           xAxisProps={xAxisProps}
           yAxisProps={yAxisProps}
-          lineSliceIndex={lineSliceIndex}
+          lineSliceEndIndex={lineSliceEndIndex}
         />
         {!onPress && <Cursor
           ref={this.cursor}

--- a/src/lib/SlideAreaChart.tsx
+++ b/src/lib/SlideAreaChart.tsx
@@ -80,9 +80,9 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
     if (initialIndicatorPosition === 'start') return 0;
     if (initialIndicatorPosition === 'middle') return chartWidth / 2;
     if (initialIndicatorPosition === "end") return chartWidth;
-    if (initialIndicatorPosition < 0) return 0;
+    if (initialIndicatorPosition < 0 || (this.props.data.length - 1) <= 0) return 0;
     if (initialIndicatorPosition > this.props.data.length) return chartWidth;
-    return chartWidth * (initialIndicatorPosition / this.props.data.length)
+    return chartWidth * (initialIndicatorPosition / (this.props.data.length - 1))
   }
 
   state: State = {

--- a/src/lib/SlideAreaChart.tsx
+++ b/src/lib/SlideAreaChart.tsx
@@ -50,6 +50,7 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
     animated: true,
     shouldCancelWhenOutside: true,
     throttleAndroid: false,
+    initialIndicatorPosition: 'middle',
   }
 
   cursor = React.createRef<Cursor>()
@@ -71,10 +72,22 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
     getDataMin(this.props.data),
     getDataMax(this.props.data)
   ]
+ 
+
+  getInitialIndicatorPosition = () => {
+    const initialIndicatorPosition = this.props.initialIndicatorPosition;
+    const chartWidth = (this.props.width - this.props.axisWidth - this.props.paddingLeft - this.props.paddingRight)
+    if (initialIndicatorPosition === 'start') return 0;
+    if (initialIndicatorPosition === 'middle') return chartWidth / 2;
+    if (initialIndicatorPosition === "end") return chartWidth;
+    if (initialIndicatorPosition < 0) return 0;
+    if (initialIndicatorPosition > this.props.data.length) return chartWidth;
+    return chartWidth * (initialIndicatorPosition / this.props.data.length)
+  }
 
   state: State = {
     x: new Animated.Value(
-      (this.props.width - this.props.axisWidth - this.props.paddingLeft - this.props.paddingRight) / 2
+      this.getInitialIndicatorPosition()
     ) as ExtendedAnimatedValue,
     cursorY: new Animated.Value(0)
   }
@@ -159,7 +172,7 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
 
     // If chart shrinks animate X as well
     const stateX = this.state.x.__getValue?.()
-    let x = this.chartWidth / 2 + axisWidth + paddingLeft
+    let x = this.getInitialIndicatorPosition() + axisWidth + paddingLeft
     let oldX: number | undefined = undefined
     if (stateX != null) {
       x = stateX + axisWidth + paddingLeft
@@ -167,8 +180,8 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
         oldX = stateX
         x = this.chartWidth + axisWidth + paddingLeft
       } else if (stateX < axisWidth + paddingLeft) {
-        oldX = stateX
-        x = axisWidth + paddingLeft
+        oldX =  stateX + axisWidth + paddingLeft
+        x = axisWidth + paddingLeft + this.getInitialIndicatorPosition()
       }
     }
 
@@ -235,7 +248,7 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
     const yRangeCalculated = this.calculateYRange()
 
     if (this.cursor.current != null && this.toolTip.current != null && this.chart.current != null) {
-      const x = (this.chartWidth / 2) + axisWidth + paddingLeft
+      const x = this.getInitialIndicatorPosition() + axisWidth + paddingLeft
       const realPercentage = (x - axisWidth - paddingLeft) / this.chartWidth
       this.cursor.current.setNativeCursorIndicatorProps({
         top: this.scaleY(yRangeCalculated[0]) - cursorMarkerHeight / 2,
@@ -456,7 +469,7 @@ class SlideAreaChart extends Component<SlideAreaChartComponentProps, State> {
     this.properties = path.svgPathProperties(this.line)
 
     if (alwaysShowIndicator) {
-      this.moveCursorBinary(this.chartWidth / 2)
+      this.moveCursorBinary(this.getInitialIndicatorPosition())
     }
 
     /**

--- a/src/lib/components/chartComponents/charts/AreaChart.tsx
+++ b/src/lib/components/chartComponents/charts/AreaChart.tsx
@@ -9,30 +9,35 @@ class AreaChart extends Component<AreaChartProps> {
   animatedPathRef = React.createRef<any>()
   animatedFillRef = React.createRef<any>()
 
+  sliceLine(line: string, index: number | undefined) {
+    if (index !== undefined) {
+      return line.split("C").slice(0, index + 1).join("C");
+    }
+    return line;
+  }
+
   // Directly manipulate the line of the area and line to allow for non state based animation
   setNativeLineProps(line: string) {
     const {
-      height,
-      axisHeight,
       data,
       scaleX,
+      scaleY,
+      yRange,
       axisWidth,
-      width,
-      paddingBottom,
       paddingLeft,
-      paddingRight,
+      lineSliceIndex,
     } = this.props
     const startX = data.length > 1 ? scaleX(data[0].x) : axisWidth + paddingLeft
-    const stopX =
-      data.length > 1 ? scaleX(data[data.length - 1].x) : width - paddingRight
     if (
       this.animatedPathRef.current != null &&
       this.animatedFillRef.current != null
-    ) {
-      const topOfLine = height - axisHeight - paddingBottom
-      this.animatedPathRef.current.setNativeProps({ d: line })
+      ) {
+      const slicedLine = this.sliceLine(line, lineSliceIndex);
+      this.animatedPathRef.current.setNativeProps({ d: slicedLine })
       this.animatedFillRef.current.setNativeProps({
-        d: `${line} L ${stopX} ${topOfLine} L ${startX} ${topOfLine}`,
+        d: `${slicedLine} V ${scaleY(yRange[0])} L ${startX} ${scaleY(
+          yRange[0]
+        )}`,
       })
     }
   }
@@ -58,11 +63,11 @@ class AreaChart extends Component<AreaChartProps> {
       paddingRight,
       paddingTop,
       paddingBottom,
+      lineSliceIndex,
     } = this.props
 
+    const slicedLine = this.sliceLine(line, lineSliceIndex);
     const startX = data.length > 1 ? scaleX(data[0].x) : axisWidth + paddingLeft
-    const stopX =
-      data.length > 1 ? scaleX(data[data.length - 1].x) : width - paddingRight
 
     return (
       <Svg {...{ width, height }}>
@@ -97,17 +102,18 @@ class AreaChart extends Component<AreaChartProps> {
         />
         <AnimatedPath
           ref={this.animatedFillRef}
-          d={`${line} L ${stopX} ${scaleY(yRange[0])} L ${startX} ${scaleY(
+          d={`${slicedLine} V ${scaleY(yRange[0])} L ${startX} ${scaleY(
             yRange[0]
           )}`}
           fill={fillColor || 'url(#gradient)'}
         />
         <AnimatedPath
           ref={this.animatedPathRef}
-          d={line}
+          d={slicedLine}
           fill='transparent'
           stroke={chartLineColor}
           strokeWidth={chartLineWidth}
+          strokeLinecap="round"
         />
       </Svg>
     )

--- a/src/lib/components/chartComponents/charts/AreaChart.tsx
+++ b/src/lib/components/chartComponents/charts/AreaChart.tsx
@@ -9,7 +9,7 @@ class AreaChart extends Component<AreaChartProps> {
   animatedPathRef = React.createRef<any>()
   animatedFillRef = React.createRef<any>()
 
-  sliceLine(line: string, index: number | undefined) {
+  sliceLineEnd(line: string, index: number | undefined) {
     if (index !== undefined) {
       return line.split("C").slice(0, index + 1).join("C");
     }
@@ -25,14 +25,14 @@ class AreaChart extends Component<AreaChartProps> {
       yRange,
       axisWidth,
       paddingLeft,
-      lineSliceIndex,
+      lineSliceEndIndex,
     } = this.props
     const startX = data.length > 1 ? scaleX(data[0].x) : axisWidth + paddingLeft
     if (
       this.animatedPathRef.current != null &&
       this.animatedFillRef.current != null
       ) {
-      const slicedLine = this.sliceLine(line, lineSliceIndex);
+      const slicedLine = this.sliceLineEnd(line, lineSliceEndIndex);
       this.animatedPathRef.current.setNativeProps({ d: slicedLine })
       this.animatedFillRef.current.setNativeProps({
         d: `${slicedLine} V ${scaleY(yRange[0])} L ${startX} ${scaleY(
@@ -63,10 +63,10 @@ class AreaChart extends Component<AreaChartProps> {
       paddingRight,
       paddingTop,
       paddingBottom,
-      lineSliceIndex,
+      lineSliceEndIndex,
     } = this.props
 
-    const slicedLine = this.sliceLine(line, lineSliceIndex);
+    const slicedLine = this.sliceLineEnd(line, lineSliceEndIndex);
     const startX = data.length > 1 ? scaleX(data[0].x) : axisWidth + paddingLeft
 
     return (

--- a/src/lib/components/chartComponents/charts/BarChart.tsx
+++ b/src/lib/components/chartComponents/charts/BarChart.tsx
@@ -63,10 +63,15 @@ class BarChart extends Component<BarChartProps, State> {
     item: { x: number | Date, y: number },
     index: number
   ) => {
-    const { fillColor, barSelectedIndex, barSelectedColor, hideSelection } = this.props
+    const { fillColor, barSelectedIndex, barSelectedColor, hideSelection, barDynamicColor } = this.props
     this.bars[index] = this.createPaths(widthOfBar, barStartX, bottomOfBar, scaleY, item)
     this.barInterpolators[index] = interpolatePath(this.bars[index].flatBar, this.bars[index].bar, null)
     const barSelected = barSelectedIndex === index
+    const getFill = () => {
+      if (barDynamicColor) return barDynamicColor({...item, index});
+      if (fillColor) return fillColor
+      return 'url(#gradient)'
+    }
     return (
       <AnimatedPath
         ref={ref => this.barRefs[index] = ref}
@@ -74,7 +79,7 @@ class BarChart extends Component<BarChartProps, State> {
         d={this.bars[index].flatBar}
         fill={barSelected && !hideSelection ?
           (barSelectedColor || 'url(#selectedGradient)') :
-          (fillColor || 'url(#gradient)')}
+          getFill()}
       />
     )
   }

--- a/src/lib/components/chartComponents/charts/utils/types.ts
+++ b/src/lib/components/chartComponents/charts/utils/types.ts
@@ -40,4 +40,5 @@ export type AreaChartProps = SharedChartProps & {
   line: string
   chartLineColor: string
   chartLineWidth: number
+  lineSliceIndex?: number
 }

--- a/src/lib/components/chartComponents/charts/utils/types.ts
+++ b/src/lib/components/chartComponents/charts/utils/types.ts
@@ -32,6 +32,8 @@ export type BarChartProps = SharedChartProps & {
   barSelectedColor?: string
   barSelectedIndex?: number
   hideSelection?: boolean
+  barDynamicColor?: ({x, y, index}: { x: number | Date; y: number, index: number }) => string;
+
 }
 
 export type AreaChartProps = SharedChartProps & {

--- a/src/lib/components/chartComponents/charts/utils/types.ts
+++ b/src/lib/components/chartComponents/charts/utils/types.ts
@@ -40,5 +40,5 @@ export type AreaChartProps = SharedChartProps & {
   line: string
   chartLineColor: string
   chartLineWidth: number
-  lineSliceIndex?: number
+  lineSliceEndIndex?: number
 }

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -96,6 +96,7 @@ export type SlideAreaChartProps = SharedChartProps & {
   chartLineColor?: string
   chartLineWidth?: number
   initialIndicatorPosition?: number | 'middle' | 'start' | 'end'
+  lineSliceIndex?: number
 }
 
 export type SlideAreaChartDefaultProps = SharedChartDefaultProps & {

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -96,7 +96,7 @@ export type SlideAreaChartProps = SharedChartProps & {
   chartLineColor?: string
   chartLineWidth?: number
   initialIndicatorPosition?: number | 'middle' | 'start' | 'end'
-  lineSliceIndex?: number
+  lineSliceEndIndex?: number
 }
 
 export type SlideAreaChartDefaultProps = SharedChartDefaultProps & {

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -71,6 +71,8 @@ type SharedBarChartProps = {
   barWidth?: number
   hideSelection?: boolean
   selectionChangedCallback?: (bar: number) => void
+  barDynamicColor?: ({x, y, index}: { x: number | Date; y: number; index: number }) => string;
+  initialBarSelected?: number
 }
 
 export type SlideBarChartProps = SharedChartProps &
@@ -93,6 +95,7 @@ export type SlideAreaChartProps = SharedChartProps & {
   cursorProps?: CursorProps
   chartLineColor?: string
   chartLineWidth?: number
+  initialIndicatorPosition?: number | 'middle' | 'start' | 'end'
 }
 
 export type SlideAreaChartDefaultProps = SharedChartDefaultProps & {
@@ -100,6 +103,7 @@ export type SlideAreaChartDefaultProps = SharedChartDefaultProps & {
   cursorProps: CursorProps
   chartLineColor: string
   chartLineWidth: number
+  initialIndicatorPosition: number | 'middle' | 'start' | 'end'
 }
 
 export type SlideAreaChartComponentProps = SlideAreaChartDefaultProps &


### PR DESCRIPTION
This pull request adds three new props to the chart components. Usage of the new props is added to the README.

BarChart:
- barDynamicColor: Function that takes the x and y value and the index of a data point and returns a color to fill the bars of the bar chart dynamically. This makes it possible to have different colors for the bars in a chart. Takes precedence over `fillColor` and `renderFillGradient` when applied.
- initialBarSelected: The initial bar that should be selected when `alwaysShowIndicator` is `true`. The `number` represents the index of the data point / bar that should be selected. Note: Old default (middle of chart) not changed.

AreaChart:
- initialIndicatorPosition: The initial location of the indicator when `alwaysShowIndicator` is `true`. The `number` represents the index of the data point / bar that should be selected. Note: old default (middle of chart) not changed.