### PR TITLE
Fix semver range syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-gesture-handler": ">1.1.0<2",
-    "react-native-svg": ">=7.0.0<12"
+    "react-native-gesture-handler": ">1.1.0 <2",
+    "react-native-svg": ">=7.0.0 <12"
   },
   "devDependencies": {
     "@babel/core": "7.8.7",


### PR DESCRIPTION
Fixes https://github.com/connectedcars/react-native-slide-charts/issues/26

Semver ranges should use space:

<img width="250" alt="image" src="https://user-images.githubusercontent.com/1812228/128713235-8b55d680-dde6-44cf-a8e3-8609e82a4361.png">
